### PR TITLE
Fix compile errors with ACS JSON schema

### DIFF
--- a/seps/draft/extensions/x-isa-acs-3-0/x-isa-acs-3-0.json
+++ b/seps/draft/extensions/x-isa-acs-3-0/x-isa-acs-3-0.json
@@ -90,7 +90,7 @@
                 },
                 "responsible_entity_custodian": {
                     "$ref": "#/definitions/custodian",
-                    "description": "custodian",
+                    "description": "custodian"
                 },
                 "responsible_entity_originator": {
                     "type": "string",
@@ -151,7 +151,7 @@
             },
             "additionalProperties": false,
             "required": [
-                "sep_version",  
+                "sep_version",
                 "identifier",
                 "create_date_time",
                 "responsible_entity_custodian",
@@ -199,7 +199,7 @@
                     ]
                 },
                 {
-                    "pattern": "\"USA.(AL|AK|AZ|AR|CA|CO|CT|DE|DC|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|AS|GU|MH|FM|MP|PW|PR|VI\""
+                    "pattern": "USA.(AL|AK|AZ|AR|CA|CO|CT|DE|DC|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|AS|GU|MH|FM|MP|PW|PR|VI)"
                 }
             ]
         },
@@ -209,7 +209,7 @@
         },
        "permitted_organizations": {
             "type": "string",
-            "$comment": "based on Table A1 in Appendix A: List of Organizations of 'Information Sharing Architecture (ISA) Access Control Specification (ACS) Version 3.0a'",
+            "$comment": "based on Table A1 in Appendix A: List of Organizations of 'Information Sharing Architecture (ISA) Access Control Specification (ACS) Version 3.0a'"
        },
         "control_set": {
             "type": "object",
@@ -330,37 +330,37 @@
              },
              "additionalProperties": false,
              "required": ["classified_by"]
-         },
-         "declassification": {
-             "type": "object",
-             "properties": {
+        },
+        "declassification": {
+            "type": "object",
+            "properties": {
                 "declass_exemption": {"type": "string"},
                 "declass_period": {"type": "integer"},
                 "declass_date": {
                     "$ref": "#/definitions/timestamp",
                     "description": "A date upon which a resource will be automatically declassified if not exempt."
-                 },
-                 "declass_event": {"type": "string"}
+                },
+                "declass_event": {"type": "string"}
             },
             "minProperties": 1,
             "additionalProperties": false
-          },
-         "resource_disposition": {
-             "type": "object",
-             "properties": {
-                 "disposition_date": {
+        },
+        "resource_disposition": {
+            "type": "object",
+            "properties": {
+                "disposition_date": {
                     "$ref": "#/definitions/timestamp",
-                     "description": "The date of the disposition is initiated"
-                 },
-                 "disposition_process": {"type": "string"}
-             },
-             "required": [
-                 "disposition_date",
-                 "disposition_process"
-             ],
-             "additionalProperties": false
-         },
-          "public_release": {
+                    "description": "The date of the disposition is initiated"
+                },
+                "disposition_process": {"type": "string"}
+            },
+            "required": [
+                "disposition_date",
+                "disposition_process"
+            ],
+            "additionalProperties": false
+        },
+        "public_release": {
             "type": "object",
             "properties": {
                 "released_by": {"type": "string"},
@@ -370,139 +370,136 @@
                 }
             },
             "required": [
-                "released_by",
+                "released_by"
             ],
             "additionalProperties": false
-          },
-          "privilege_scope": {
-              "type": "object",
-              "$comment": "At least one property must be present",
-              "allOf": [
-                  {
-                      "properties": {
-                          "permitted_nationalities": {
-                              "$comment": "use oneOf construction (see entity), once permitted_nationalities is the actual enum",
-                              "type": "array",
-                              "anyOf": [
-                                  {
+        },
+        "privilege_scope": {
+            "type": "object",
+            "$comment": "At least one property must be present",
+            "allOf": [
+                {
+                    "properties": {
+                        "permitted_nationalities": {
+                            "$comment": "use oneOf construction (see entity), once permitted_nationalities is the actual enum",
+                            "type": "array",
+                            "anyOf": [
+                                {
                                     "items": { "$ref": "#/definitions/permitted_nationalities"}
-                                  },
-                                  {
-                                      "items": {
-                                          "type": "string",
-                                          "enum": [ "ALL" ]
-                                      },
-                                      "max_items": 1
-                                  }
-                              ]
-                          },
-                          "permitted_organizations": {
-                              "$comment": "use oneOf construction (see entity), once permitted_organizations defined based on Appendix A of ACS 3.0a specification",
-                              "type": "array",
-                              "anyOf": [
-                                  {
+                                },
+                                {
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [ "ALL" ]
+                                    },
+                                    "max_items": 1
+                                }
+                            ]
+                        },
+                        "permitted_organizations": {
+                            "$comment": "use oneOf construction (see entity), once permitted_organizations defined based on Appendix A of ACS 3.0a specification",
+                            "type": "array",
+                            "anyOf": [
+                                {
                                     "items": { "$ref": "#/definitions/permitted_organizations"}
-                                  },
-                                  {
-                                      "items": {
-                                          "type": "string",
-                                          "enum": [ "ALL" ]
-                                      },
-                                      "max_items": 1
-                                  }
-                              ]
-                          },
-                          "shareability": {
-                              "type": "array",
-                              "oneOf": [
-                                  {
-                                      "items": {"$ref":"#/definitions/shareability"}
-                                  },
-                                  {
-                                      "items": {
-                                          "type": "string",
-                                          "enum": [ "ALL" ]
-                                      },
-                                      "max_items": 1
-                                  }
-                              ]
-                          },
-                          "entity": {
-                              "type": "array",
-                              "oneOf": [
-                                  {
-                                      "items": {"$ref":"#/definitions/entity"}
-                                  },
-                                  {
-                                      "items":
-                                          {
-                                              "type": "string",
-                                              "enum": [ "ALL" ]
-                                          },
-                                          "max_items": 1
-                                  }
-                              ]
-                          }
-                      }
-                  },
-                  {
-                      "anyOf": [
-                          { "required": ["permitted_nationalities"] },
-                          { "required": ["permitted_organizations"] },
-                          { "required": ["shareability"] },
-                          { "required": ["entity"] }
-                      ]
-                  }
-              ]
-          },
-          "access_privilege": {
-              "type": "object",
-              "properties": {
-                  "privilege_action": {
-                      "type": "string",
-                      "enum": [
-                          "DSPLY", "IDSRC", "TENOT", "NETDEF", "LEGAL", "INTEL",
-                          "TEARLINE", "OPACTION", "REQUEST", "ANONYMOUSACCESS", "CISAUSES",
-                          "ALL"
-                      ]
-                  },
-                  "privilege_scope": {
-                      "$ref": "#/definitions/privilege_scope"
-                  },
-                  "rule_effect": {
-                      "type": "string",
-                      "enum": [ "permit", "deny"]
-                  }
-              },
-              "additionalProperties": false,
-              "required": [
+                                },
+                                {
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [ "ALL" ]
+                                    },
+                                    "max_items": 1
+                                }
+                            ]
+                        },
+                        "shareability": {
+                            "type": "array",
+                            "oneOf": [
+                                {
+                                    "items": {"$ref":"#/definitions/shareability"}
+                                },
+                                {
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [ "ALL" ]
+                                    },
+                                    "max_items": 1
+                                }
+                            ]
+                        },
+                        "entity": {
+                            "type": "array",
+                            "oneOf": [
+                                {
+                                    "items": {"$ref":"#/definitions/entity"}
+                                },
+                                {
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [ "ALL" ]
+                                    },
+                                    "max_items": 1
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "anyOf": [
+                        { "required": ["permitted_nationalities"] },
+                        { "required": ["permitted_organizations"] },
+                        { "required": ["shareability"] },
+                        { "required": ["entity"] }
+                    ]
+                }
+            ]
+        },
+        "access_privilege": {
+            "type": "object",
+            "properties": {
+                "privilege_action": {
+                    "type": "string",
+                    "enum": [
+                        "DSPLY", "IDSRC", "TENOT", "NETDEF", "LEGAL", "INTEL",
+                        "TEARLINE", "OPACTION", "REQUEST", "ANONYMOUSACCESS", "CISAUSES",
+                        "ALL"
+                    ]
+                },
+                "privilege_scope": {
+                    "$ref": "#/definitions/privilege_scope"
+                },
+                "rule_effect": {
+                    "type": "string",
+                    "enum": [ "permit", "deny"]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
                 "privilege_action",
                 "privilege_scope",
                 "rule_effect"
-              ]
-          },
-          "further_sharing": {
-              "type": "object",
-              "properties": {
-                  "sharing_scope": {
-                      "type": "array",
-                      "items": {
-                          "type": "string",
-                          "$comment": "based on Appendix A of ACS 3.0 specification"
-                      }
-                  },
-                  "rule_effect": {
-                      "type": "string",
-                      "enum": [ "permit", "deny"]
-                  }
-              },
-              "additionalProperties": false,
-              "required": [
+            ]
+        },
+        "further_sharing": {
+            "type": "object",
+            "properties": {
+                "sharing_scope": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "$comment": "based on Appendix A of ACS 3.0 specification"
+                    }
+                },
+                "rule_effect": {
+                    "type": "string",
+                    "enum": [ "permit", "deny"]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
                 "sharing_scope",
                 "rule_effect"
-              ]
-          }
-       }
-   }
-
-
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Our project is integrating ACS Marking Definition now and I used this schema with a Java JSON schema validator.

Here are the modifications I made and tested:

* Remove unnecessary commas
* Close pattern group
* Remove pair of escaped quotation marks from pattern causing regex to look for exact match of entire pattern string
* Adjust indenting to be multiples of 4